### PR TITLE
Retry to download failed batches, Issues #16 & #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Recommended naming scheme: `<Marker>.<Taxonomic Group>.<country code>.<date>`
 
 Basic:
  - Sequence fasta (filtered/trimmed/sintax style taxonomy header)
- 
+
 Additional:
  - Report (e.g. Taxonomy table (Krona))
 
@@ -87,7 +87,7 @@ Perl Modules:
  - FindBin
  - Log::Log4perl
  - Getopt::Long
- - Getopt::ArgvFile 
+ - Getopt::ArgvFile
  - File::Path
  - [NCBI::Taxonomy](https://github.com/greatfireball/NCBI-Taxonomy)
 
@@ -95,7 +95,7 @@ External Programs:
  - [NCBI eutils](https://www.ncbi.nlm.nih.gov/books/NBK25500)
  - [KronaTools](https://github.com/marbl/Krona)
  - [SeqFilter](https://github.com/BioInf-Wuerzburg/SeqFilter)
- - [dispr](https://github.com/molbiodiv/metabDB/issues)
+ - [dispr](https://github.com/douglasgscofield/dispr)
 
 ## Examples
 
@@ -291,11 +291,11 @@ Options:
 
     [--version]              show version number of bcdatabaser and exit
 ```
- 
+
 ## Dataset Upload
 Automated dataset upload to zenodo is possible. You have to supply a file containing the zenodo token to bcdatabaser.
 The dataset is uploaded in the name of the owner of that token. If that's you, you are able to modify metadata but not to delete the record.
- 
+
 ## Logo
 The current logo is designed by [@mirzazulfan](https://github.com/mirzazulfan).
 Thanks a lot Mirza!

--- a/lib/BCdatabaser.pm
+++ b/lib/BCdatabaser.pm
@@ -380,13 +380,18 @@ sub run_command_download_sequences{
 	my $msg = shift;
 	my $ignore_error = shift;
 	my $retries = 0;
-	my $max_retries = 3;
+	my $max_retries = 3; # Maximum Number of download attempts (includes the first attempt)
+	my $wait_time = 60; # Time to wait after a failed download attempt in seconds
 
 	while($retries <= $max_retries){
 		$retries ++;
 		$L->logdie("ERROR: Reached maximum amount of retries: \n$msg") if $retries >= $max_retries;
 		$L->info("Starting: $msg") if $retries == 1;
-		$L->info("Retrying: $msg") if $retries > 1;
+		if ($retries > 1){
+			$L->info("Retrying in $wait_time seconds");
+			sleep($wait_time);
+			$L->info("Retrying: $msg");
+		}
 		$L->info($cmd);
 		my $result = qx($cmd);
 		$L->debug($result);
@@ -395,7 +400,6 @@ sub run_command_download_sequences{
 		}
 		else{
 			$L->info("Finished: $msg");
-			$retries = $max_retries;
 			return $result;
 		}
 	}

--- a/lib/BCdatabaser.pm
+++ b/lib/BCdatabaser.pm
@@ -387,7 +387,7 @@ sub run_command_download_sequences{
 		$L->logdie("ERROR: Reached maximum amount of retries: $msg") if $retries >= $max_retries;
 		$L->info("Starting: $msg") if $retries == 1;
 		$L->info("Retrying: $msg") if $retries > 1;
-		$L->info($cmd):
+		$L->info($cmd);
 		my $result = qx($cmd);
 		$L->debug($result);
 		if ($? >> 8){

--- a/lib/BCdatabaser.pm
+++ b/lib/BCdatabaser.pm
@@ -385,8 +385,9 @@ sub run_command_download_sequences{
 	while($retries < $max_retries){
 		$retries ++;
 		$L->logdie("ERROR: Reached maximum amount of retries: $msg") if $retries >= $max_retries;
-		$L->info("Starting: $msg") if retries == 1;
-		$L->info("Retrying: $msg") if retries > 1;
+		$L->info("Starting: $msg") if $retries == 1;
+		$L->info("Retrying: $msg") if $retries > 1;
+		$L->info($cmd):
 		my $result = qx($cmd);
 		$L->debug($result);
 		if ($? >> 8){

--- a/lib/BCdatabaser.pm
+++ b/lib/BCdatabaser.pm
@@ -382,9 +382,9 @@ sub run_command_download_sequences{
 	my $retries = 0;
 	my $max_retries = 3;
 
-	while($retries < $max_retries){
+	while($retries <= $max_retries){
 		$retries ++;
-		$L->logdie("ERROR: Reached maximum amount of retries: $msg") if $retries >= $max_retries;
+		$L->logdie("ERROR: Reached maximum amount of retries: \n$msg") if $retries >= $max_retries;
 		$L->info("Starting: $msg") if $retries == 1;
 		$L->info("Retrying: $msg") if $retries > 1;
 		$L->info($cmd);

--- a/lib/BCdatabaser.pm
+++ b/lib/BCdatabaser.pm
@@ -147,12 +147,12 @@ sub download_sequences{
 	if ( -e $outdir."/sequences.fa" ) {
         unlink($outdir."/sequences.fa") or $L->logdie("$!");
     }
-	
+
 	$L->info("Now downloading sequences in batches of $batch_size");
 	for(my $i=1; $i<=$num_results; $i+=$batch_size){
 		my $msg = "Downloading fasta sequences for batch: $i - ".($i+$batch_size-1);
 		my $cmd = "tail -n+$i $outdir/list.filtered.txt | head -n $batch_size | cut -f1 | $epost_bin -db nuccore | $efetch_bin -format fasta >>$outdir/sequences.fa";
-		$self->run_command($cmd, $msg);
+		$self->run_command_download_sequences($cmd, $msg);
 	}
 	$L->info("Finished downloading sequences");
 }
@@ -374,5 +374,30 @@ sub run_command{
 	return $result;
 }
 
+sub run_command_download_sequences{
+	my $self = shift;
+	my $cmd = shift;
+	my $msg = shift;
+	my $ignore_error = shift;
+	my $retries = 0;
+	my $max_retries = 3;
+
+	while($retries < $max_retries){
+		$retries ++;
+		$L->logdie("ERROR: Reached maximum amount of retries: $msg") if $retries >= $max_retries;
+		$L->info("Starting: $msg") if retries == 1;
+		$L->info("Retrying: $msg") if retries > 1;
+		my $result = qx($cmd);
+		$L->debug($result);
+		if ($? >> 8){
+			$L->warn("WARNING: $msg failed");
+		}
+		else{
+			$L->info("Finished: $msg");
+			$retries = $max_retries;
+			return $result;
+		}
+	}
+}
 
 1;


### PR DESCRIPTION
If the download of a batch failes, BCdatabaser now tries to download it again after 60 seconds, up to a maximum of three tries. As a result, the tool does not have to be completely rerun in the event of brief connection interruptions, which is particularly helpful when working with large databases.

You can find a Docker image of this branch [here](https://hub.docker.com/r/laskru/bcdatabaser). 

A logfile from a run with 5 downloading errors and used command (trnl, all viridiplantae) can be found [here](https://github.com/molbiodiv/bcdatabaser/files/7454990/bcdatabaser.log). You can find the errors by searching for "WARNING". 

This my first time contributing to someone elses project and my first time writing perl code, I'm open to suggestions of all kinds.

